### PR TITLE
Fix macro issues inside RTE (#31)

### DIFF
--- a/src/Perplex.ContentBlocks/Perplex.ContentBlocks.csproj
+++ b/src/Perplex.ContentBlocks/Perplex.ContentBlocks.csproj
@@ -267,6 +267,7 @@
     <Compile Include="Preview\CookieBasedPreviewModeProvider.cs" />
     <Compile Include="Preview\IPreviewModeProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PropertyEditor\ContentBlocksValueEditor.cs" />
     <Compile Include="Providers\ContentBlockProvidersComposer.cs" />
     <Compile Include="Providers\DocumentTypeAliasProvider.cs" />
     <Compile Include="Providers\IDocumentTypeAliasProvider.cs" />
@@ -292,6 +293,8 @@
     <Compile Include="PropertyEditor\Configuration\ContentBlocksConfigurationEditor.cs" />
     <Compile Include="PropertyEditor\ContentBlocksPropertyEditor.cs" />
     <Compile Include="PropertyEditor\ContentBlocksValidator.cs" />
+    <Compile Include="Utils\ContentBlockUtilsComposer.cs" />
+    <Compile Include="Utils\ContentBlockUtils.cs" />
     <Compile Include="Utils\Cookies\CookiesComposer.cs" />
     <Compile Include="Utils\Cookies\HttpCookiesAccessor.cs" />
     <Compile Include="Utils\Cookies\IHttpCookiesAccessor.cs" />

--- a/src/Perplex.ContentBlocks/PropertyEditor/ContentBlocksPropertyEditor.cs
+++ b/src/Perplex.ContentBlocks/PropertyEditor/ContentBlocksPropertyEditor.cs
@@ -1,26 +1,22 @@
 ﻿using Perplex.ContentBlocks.PropertyEditor.Configuration;
 using Perplex.ContentBlocks.PropertyEditor.ModelValue;
+using Perplex.ContentBlocks.Utils;
 using System.Collections.Generic;
-using Umbraco.Core.Composing;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Core.Services;
 
 namespace Perplex.ContentBlocks.PropertyEditor
 {
     public class ContentBlocksPropertyEditor : IDataEditor
     {
-        private readonly IDataTypeService _dataTypeService;
         private readonly ContentBlocksModelValueDeserializer _deserializer;
-        private readonly IFactory _factory;
+        private readonly ContentBlockUtils _utils;
 
         public ContentBlocksPropertyEditor(
-            IDataTypeService dataTypeService,
             ContentBlocksModelValueDeserializer deserializer,
-            IFactory factory)
+            ContentBlockUtils utils)
         {
-            _dataTypeService = dataTypeService;
             _deserializer = deserializer;
-            _factory = factory;
+            _utils = utils;
         }
 
         public string Alias { get; } = Constants.PropertyEditor.Alias;
@@ -47,12 +43,12 @@ namespace Perplex.ContentBlocks.PropertyEditor
 
         public IDataValueEditor GetValueEditor(object configuration)
         {
-            var validator = new ContentBlocksValidator(_dataTypeService, _deserializer, _factory);
+            var validator = new ContentBlocksValidator(_deserializer, _utils);
 
             bool hideLabel = (configuration as ContentBlocksConfiguration)?.HideLabel
                 ?? ContentBlocksConfigurationEditor._defaultConfiguration.HideLabel;
 
-            return new DataValueEditor(Constants.PropertyEditor.ViewPath, validator)
+            return new ContentBlocksValueEditor(Constants.PropertyEditor.ViewPath, _deserializer, _utils, validator)
             {
                 Configuration = configuration,
                 HideLabel = hideLabel,

--- a/src/Perplex.ContentBlocks/PropertyEditor/ContentBlocksValidator.cs
+++ b/src/Perplex.ContentBlocks/PropertyEditor/ContentBlocksValidator.cs
@@ -1,33 +1,26 @@
-﻿using Perplex.ContentBlocks.Definitions;
-using Perplex.ContentBlocks.PropertyEditor.Configuration;
+﻿using Perplex.ContentBlocks.PropertyEditor.Configuration;
 using Perplex.ContentBlocks.PropertyEditor.ModelValue;
-using System;
+using Perplex.ContentBlocks.Utils;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Umbraco.Core;
-using Umbraco.Core.Composing;
 using Umbraco.Core.Models;
 using Umbraco.Core.PropertyEditors;
-using Umbraco.Core.Services;
 
 namespace Perplex.ContentBlocks.PropertyEditor
 {
     public class ContentBlocksValidator : IValueValidator
     {
-        private readonly IDataTypeService _dataTypeService;
+        private readonly ContentBlockUtils _utils;
         private readonly ContentBlocksModelValueDeserializer _deserializer;
-        private readonly Lazy<IContentBlockDefinitionRepository> _definitionRepository;
 
         public ContentBlocksValidator(
-            IDataTypeService dataTypeService,
             ContentBlocksModelValueDeserializer deserializer,
-            IFactory factory)
+            ContentBlockUtils utils)
         {
-            _dataTypeService = dataTypeService;
             _deserializer = deserializer;
-            _definitionRepository = new Lazy<IContentBlockDefinitionRepository>(() => factory.GetInstance<IContentBlockDefinitionRepository>());
+            _utils = utils;
         }
 
         public IEnumerable<ValidationResult> Validate(object value, string valueType, object dataTypeConfiguration)
@@ -65,27 +58,7 @@ namespace Perplex.ContentBlocks.PropertyEditor
                 return Enumerable.Empty<ValidationResult>();
             }
 
-            var repository = _definitionRepository.Value;
-            if (repository == null)
-            {
-                return Enumerable.Empty<ValidationResult>();
-            }
-
-            var definition = repository.GetById(blockValue.DefinitionId);
-            if (definition == null)
-            {
-                return Enumerable.Empty<ValidationResult>();
-            }
-
-            IDataType dataType = null;
-            if (definition.DataTypeId is int dataTypeId)
-            {
-                dataType = _dataTypeService.GetDataType(dataTypeId);
-            }
-            else if (definition.DataTypeKey is Guid dataTypeKey)
-            {
-                dataType = _dataTypeService.GetDataType(dataTypeKey);
-            }
+            IDataType dataType = _utils.GetDataType(blockValue.DefinitionId);
 
             if (dataType == null)
             {

--- a/src/Perplex.ContentBlocks/PropertyEditor/ContentBlocksValueEditor.cs
+++ b/src/Perplex.ContentBlocks/PropertyEditor/ContentBlocksValueEditor.cs
@@ -1,0 +1,114 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Perplex.ContentBlocks.PropertyEditor.ModelValue;
+using Perplex.ContentBlocks.Utils;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.Editors;
+using Umbraco.Core.PropertyEditors;
+using Umbraco.Core.Services;
+
+namespace Perplex.ContentBlocks.PropertyEditor
+{
+    public class ContentBlocksValueEditor : DataValueEditor
+    {
+        private readonly ContentBlocksModelValueDeserializer _deserializer;
+        private readonly ContentBlockUtils _utils;
+
+        public ContentBlocksValueEditor(string view, ContentBlocksModelValueDeserializer deserializer, ContentBlockUtils utils, params IValueValidator[] validators) : base(view, validators)
+        {
+            _deserializer = deserializer;
+            _utils = utils;
+        }
+
+        public override object FromEditor(ContentPropertyData editorValue, object currentValue)
+        {
+            string json = editorValue.Value?.ToString();
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
+            var modelValue = _deserializer.Deserialize(json);
+            if (modelValue == null)
+            {
+                return null;
+            }
+
+            JArray fromEditor(ContentBlockModelValue block)
+            {
+                if (_utils.GetDataType(block.DefinitionId) is IDataType dataType &&
+                    dataType.Editor?.GetValueEditor() is IDataValueEditor valueEditor)
+                {
+                    var propertyData = new ContentPropertyData(block.Content.ToString(), dataType.Configuration);
+                    var ncJson = valueEditor.FromEditor(propertyData, null)?.ToString();
+
+                    if (!string.IsNullOrWhiteSpace(ncJson))
+                    {
+                        return JArray.Parse(ncJson);
+                    }
+                }
+
+                return null;
+            }
+
+            if (modelValue.Header != null)
+            {
+                modelValue.Header.Content = fromEditor(modelValue.Header);
+            }
+
+            if (modelValue.Blocks?.Any() == true)
+            {
+                foreach (var block in modelValue.Blocks)
+                {
+                    block.Content = fromEditor(block);
+                }
+            }
+
+            return JsonConvert.SerializeObject(modelValue, Formatting.None);
+        }
+
+        public override object ToEditor(Property property, IDataTypeService dataTypeService, string culture = null, string segment = null)
+        {
+            string json = property.GetValue(culture, segment)?.ToString();
+            var modelValue = _deserializer.Deserialize(json);
+            if (modelValue == null)
+            {
+                return null;
+            }
+
+            JArray toEditor(ContentBlockModelValue block)
+            {
+                if (_utils.GetDataType(block.DefinitionId) is IDataType dataType &&
+                    dataType.Editor?.GetValueEditor() is IDataValueEditor valueEditor)
+                {
+                    var ncPropType = new PropertyType(dataType);
+                    var ncProperty = new Property(ncPropType);
+                    ncProperty.SetValue(block.Content?.ToString());
+                    if (valueEditor.ToEditor(ncProperty, dataTypeService, culture, segment) is List<JObject> ncValue)
+                    {
+                        return JArray.FromObject(ncValue);
+                    }
+                }
+
+                return null;
+            }
+
+            if (modelValue.Header != null)
+            {
+                modelValue.Header.Content = toEditor(modelValue.Header);
+            }
+
+            if (modelValue.Blocks?.Any() == true)
+            {
+                foreach (var block in modelValue.Blocks)
+                {
+                    block.Content = toEditor(block);
+                }
+            }
+
+            return JObject.FromObject(modelValue);
+        }
+    }
+}

--- a/src/Perplex.ContentBlocks/PropertyEditor/ModelValue/ContentBlockModelValue.cs
+++ b/src/Perplex.ContentBlocks/PropertyEditor/ModelValue/ContentBlockModelValue.cs
@@ -1,27 +1,34 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 
 namespace Perplex.ContentBlocks.PropertyEditor.ModelValue
 {
     public class ContentBlockModelValue
     {
+        [JsonProperty("id")]
         public Guid Id { get; set; }
 
+        [JsonProperty("definitionId")]
         public Guid DefinitionId { get; set; }
 
+        [JsonProperty("layoutId")]
         public Guid LayoutId { get; set; }
 
         /// <summary>
         /// Indien dit blok uit een preset komt zal dit een waarde hebben
         /// en wijzen naar de betreffende IContentBlockPreset
         /// </summary>
+        [JsonProperty("presetId")]
         public Guid? PresetId { get; set; }
 
+        [JsonProperty("isDisabled")]
         public bool IsDisabled { get; set; }
 
         /// <summary>
         /// JSON NestedContent
         /// </summary>
+        [JsonProperty("content")]
         public JArray Content { get; set; }
     }
 }

--- a/src/Perplex.ContentBlocks/PropertyEditor/ModelValue/ContentBlocksModelValue.cs
+++ b/src/Perplex.ContentBlocks/PropertyEditor/ModelValue/ContentBlocksModelValue.cs
@@ -1,13 +1,17 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Perplex.ContentBlocks.PropertyEditor.ModelValue
 {
     public class ContentBlocksModelValue
     {
+        [JsonProperty("version")]
         public int Version { get; set; }
 
+        [JsonProperty("header")]
         public ContentBlockModelValue Header { get; set; }
 
+        [JsonProperty("blocks")]
         public List<ContentBlockModelValue> Blocks { get; set; }
     }
 }

--- a/src/Perplex.ContentBlocks/Utils/ContentBlockUtils.cs
+++ b/src/Perplex.ContentBlocks/Utils/ContentBlockUtils.cs
@@ -1,0 +1,69 @@
+﻿using Perplex.ContentBlocks.Definitions;
+using System;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+
+namespace Perplex.ContentBlocks.Utils
+{
+    /// <summary>
+    /// General ContentBlocks utility functions
+    /// </summary>
+    public class ContentBlockUtils
+    {
+        private readonly IDataTypeService _dataTypeService;
+        private readonly Lazy<IContentBlockDefinitionRepository> _definitionRepository;
+
+        public ContentBlockUtils(IDataTypeService dataTypeService, Lazy<IContentBlockDefinitionRepository> definitionRepository)
+        {
+            _dataTypeService = dataTypeService;
+            _definitionRepository = definitionRepository;
+        }
+
+        /// <summary>
+        /// Returns the dataType associated with the ContentBlock with the given definitionId.
+        /// </summary>
+        /// <param name="definitionId">Id of the ContentBlock definition</param>
+        /// <returns></returns>
+        public IDataType GetDataType(Guid definitionId)
+        {
+            var definition = _definitionRepository.Value.GetById(definitionId);
+            if (definition == null)
+            {
+                throw new InvalidOperationException($"No ContentBlock definition found for id \"{definitionId}\"");
+            }
+
+            return GetDataType(definition);
+        }
+
+        /// <summary>
+        /// Returns the dataType associated with the given ContentBlock definition
+        /// </summary>
+        /// <param name="definition">ContentBlock definition</param>
+        /// <returns></returns>
+        public IDataType GetDataType(IContentBlockDefinition definition)
+        {
+            if (definition == null)
+            {
+                throw new ArgumentNullException(nameof(definition));
+            }
+
+            IDataType dataType = null;
+
+            if (definition.DataTypeId is int dataTypeId)
+            {
+                dataType = _dataTypeService.GetDataType(dataTypeId);
+            }
+            else if (definition.DataTypeKey is Guid dataTypeKey)
+            {
+                dataType = _dataTypeService.GetDataType(dataTypeKey);
+            }
+
+            if (dataType.EditorAlias != Umbraco.Core.Constants.PropertyEditors.Aliases.NestedContent)
+            {
+                throw new InvalidOperationException($"DataType should be Nested Content, but was '{dataType.EditorAlias}'");
+            }
+
+            return dataType;
+        }
+    }
+}

--- a/src/Perplex.ContentBlocks/Utils/ContentBlockUtilsComposer.cs
+++ b/src/Perplex.ContentBlocks/Utils/ContentBlockUtilsComposer.cs
@@ -1,0 +1,14 @@
+﻿using Umbraco.Core;
+using Umbraco.Core.Composing;
+
+namespace Perplex.ContentBlocks.Utils
+{
+    [RuntimeLevel(MinLevel = RuntimeLevel.Boot)]
+    public class ContentBlockUtilsComposer : IUserComposer
+    {
+        public void Compose(Composition composition)
+        {
+            composition.Register<ContentBlockUtils>(Lifetime.Singleton);
+        }
+    }
+}


### PR DESCRIPTION
The property value of macros in RTEs were not stored correctly and as a
result rendering on the front-end was incorrect as well.

We have implemented a DataValueEditor on the server now that implements
FromEditor() + ToEditor() which in turn calls NestedContent's
FromEditor() + ToEditor() which do the heavy lifting for us.