### PR TITLE
Fix missing data in backoffice in some cases

### DIFF
--- a/src/Perplex.ContentBlocks/PropertyEditor/ContentBlocksValueEditor.cs
+++ b/src/Perplex.ContentBlocks/PropertyEditor/ContentBlocksValueEditor.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json.Linq;
 using Perplex.ContentBlocks.PropertyEditor.ModelValue;
 using Perplex.ContentBlocks.Utils;
-using System.Collections.Generic;
+using System;
 using System.Linq;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.Editors;
@@ -85,9 +85,18 @@ namespace Perplex.ContentBlocks.PropertyEditor
 
                     var ncProperty = new Property(ncPropType);
                     ncProperty.SetValue(block.Content?.ToString(), culture, segment);
-                    if (valueEditor.ToEditor(ncProperty, dataTypeService, culture, segment) is List<JObject> ncValue)
+
+                    var ncValue = valueEditor.ToEditor(ncProperty, dataTypeService, culture, segment);
+                    if (ncValue != null)
                     {
-                        return JArray.FromObject(ncValue);
+                        try
+                        {
+                            return JArray.FromObject(ncValue);
+                        }
+                        catch (ArgumentException)
+                        {
+                            return block.Content;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Caused by NestedContent's ToEditor() method returning a different object
since Umbraco 8.7.

Fixes #38 