### PR TITLE
Revert "Use dataTypeResource.getById instead of .getAll to fetch by key"

### DIFF
--- a/src/Perplex.ContentBlocks/App_Plugins/Perplex.ContentBlocks/utils/property/perplex.content-blocks.property-scaffold-cache.js
+++ b/src/Perplex.ContentBlocks/App_Plugins/Perplex.ContentBlocks/utils/property/perplex.content-blocks.property-scaffold-cache.js
@@ -14,7 +14,10 @@
 
         function getByKey(key) {
             if (dataTypeKeyToId[key] == null) {
-                dataTypeKeyToId[key] = dataTypeResource.getById(key).then(function (dataType) {
+                dataTypeKeyToId[key] = dataTypeResource.getAll().then(function (dataTypes) {
+                    var dataType = _.find(dataTypes, function (dataType) {
+                        return dataType.key === key;
+                    });
                     if (dataType == null) {
                         throw new Error('No data type found with key "' + key + '"');
                     }


### PR DESCRIPTION
This reverts commit ee3223b4c0f1b72810086a83b40356f28f322999.