### PR TITLE
Fix saving Image Cropper and File Upload editors inside a block

### DIFF
--- a/src/Perplex.ContentBlocks.Core/PropertyEditor/ContentBlocksValueEditor.cs
+++ b/src/Perplex.ContentBlocks.Core/PropertyEditor/ContentBlocksValueEditor.cs
@@ -117,7 +117,11 @@ public class ContentBlocksValueEditor : DataValueEditor, IDataValueReference
                     continue;
                 }
 
-                var propData = new ContentPropertyData(prop.Value, configuration);
+                var propData = new ContentPropertyData(prop.Value, configuration)
+                {
+                    ContentKey = editorValue.ContentKey,
+                    PropertyTypeKey = prop.PropertyType.Key,
+                };
                 prop.Value = valueEditor.FromEditor(propData, prop.Value);
             }
         }


### PR DESCRIPTION
Fixes #102.

If you put an Umbraco Image Cropper or File Upload editor on a block's element type, saving the page fails with "Invalid content key". In `ContentBlocksValueEditor.FromEditor` the inner `ContentPropertyData` is created without a `ContentKey` or `PropertyTypeKey`, so both default to `Guid.Empty`. `ImageCropperPropertyValueEditor` and `FileUploadPropertyValueEditor` both explicitly throw `"Invalid content key"` in that case, and need the key to build the media storage path. Editors that only store a reference (e.g. Media Picker v3) ignore the two keys, which is why everything else saves fine.

This sets both keys before calling the inner `FromEditor`, taking the content key from the incoming `editorValue` – the same approach Umbraco core takes in `BlockValuePropertyValueEditorBase.MapBlockItemDataFromEditor` (umbraco/Umbraco-CMS#18976).

Verified on Umbraco 17: with this change the Image Cropper saves correctly inside a block (the file is stored against the content), and reference-based editors like Media Picker are unaffected (Media Picker stores a media-library reference, not a file on the content). File Upload uses the same content-key mechanism as the Image Cropper – the identical `"Invalid content key"` guard – so it's covered by the same fix.